### PR TITLE
fix(ELY-654): Remove dots from environment variable names

### DIFF
--- a/kafka-connect-ccloud/ccloud.py
+++ b/kafka-connect-ccloud/ccloud.py
@@ -19,7 +19,7 @@ def create_connection_config():
     config = {}
     for k, v in os.environ.items():
         if k[:11] == 'CONNECTION_':
-            config[k[11:]] = v
+            config[k[11:]] = v.replace('__', '.')
     open('connection.config', 'w').write(json.dumps(config, indent=2))
 
 

--- a/kafka-connect-ccloud/main.tf
+++ b/kafka-connect-ccloud/main.tf
@@ -36,7 +36,7 @@ resource "shell_script" "connection" {
       CONFLUENT_ENVIRONMENT = var.confluent_environment,
       CONFLUENT_CLUSTER     = var.confluent_cluster,
     },
-    { for k, v in var.connection_config : "CONNECTION_${k}" => v }
+    { for k, v in var.connection_config : "CONNECTION_${replace(k, ".", "__")}" => v }
   )
 
   sensitive_environment = merge(
@@ -44,7 +44,7 @@ resource "shell_script" "connection" {
       CONFLUENT_USERNAME = (var.confluent_project_gcp_secret != "") ? data.google_secret_manager_secret_version.confluent_username[0].secret_data : var.confluent_username
       CONFLUENT_PASSWORD = (var.confluent_project_gcp_secret != "") ? data.google_secret_manager_secret_version.confluent_password[0].secret_data : var.confluent_password
     },
-    { for k, v in var.connection_sensitive_config : "CONNECTION_${k}" => v },
-    { for k, v in var.connection_gcp_secret_config : "CONNECTION_${k}" => data.google_secret_manager_secret_version.connection_secret_config[k].secret_data }
+    { for k, v in var.connection_sensitive_config : "CONNECTION_${replace(k, ".", "__")}" => v },
+    { for k, v in var.connection_gcp_secret_config : "CONNECTION_${replace(k, ".", "__")}" => data.google_secret_manager_secret_version.connection_secret_config[k].secret_data }
   )
 }


### PR DESCRIPTION
Connection configuration often has dots in the names.
However, passing variables having dots in their names doesn't work in all OSes and bash versions.
This PR makes the terraform module work in all bash versions.