### PR TITLE
feat: Implement ability to import existing connection

### DIFF
--- a/kafka-connect-ccloud/ccloud.py
+++ b/kafka-connect-ccloud/ccloud.py
@@ -7,6 +7,9 @@ import subprocess
 import tarfile
 
 
+import_existing_connection = True
+
+
 def download_ccloud():
     if not os.path.exists('ccloud/ccloud'):
         url = 'https://s3-us-west-2.amazonaws.com/confluent.cloud/ccloud-cli/archives/latest/ccloud_latest_%s_amd64.tar.gz' % sys.platform
@@ -47,6 +50,14 @@ def get_real_connection_config(environment, cluster, id):
         config[ i['config'] ] = i['value']
     return config
 
+
+def get_existing_connection_id(environment, cluster, name):
+    cmd = subprocess.run('./ccloud/ccloud connector list --environment %s --cluster %s -o json' % (environment, cluster), shell=True, stdout=subprocess.PIPE, encoding='utf-8', timeout=60)
+    connectors = json.loads(cmd.stdout)
+    for connector in connectors:
+        if connector['name'] == name:
+            return connector['id']
+
 # ------------ terraform commands ------------
 
 def create():
@@ -54,12 +65,15 @@ def create():
 
     environment = os.environ['CONFLUENT_ENVIRONMENT']
     cluster = os.environ['CONFLUENT_CLUSTER']
-    create_connection_config()
-    cmd = subprocess.run('./ccloud/ccloud connector create --environment %s --cluster %s --config connection.config' % (environment, cluster), shell=True, stdout=subprocess.PIPE, encoding='utf-8', timeout=300)
-    delete_connection_config()
-    if cmd.returncode != 0:
-        sys.exit(cmd.returncode)
-    id = cmd.stdout.split(' ')[-1].strip()
+
+    id = get_existing_connection_id(environment, cluster, os.environ['CONNECTION_name']) if import_existing_connection else None
+    if not id:
+        create_connection_config()
+        cmd = subprocess.run('./ccloud/ccloud connector create --environment %s --cluster %s --config connection.config' % (environment, cluster), shell=True, stdout=subprocess.PIPE, encoding='utf-8', timeout=300)
+        delete_connection_config()
+        if cmd.returncode != 0:
+            sys.exit(cmd.returncode)
+        id = cmd.stdout.split(' ')[-1].strip()
 
     output = get_real_connection_config(environment, cluster, id)
     print(json.dumps(output))

--- a/kafka-connect-ccloud/ccloud.py
+++ b/kafka-connect-ccloud/ccloud.py
@@ -7,7 +7,7 @@ import subprocess
 import tarfile
 
 
-import_existing_connection = True
+import_existing_connection = False
 
 
 def download_ccloud():


### PR DESCRIPTION
Sometimes rarely `ccloud` command returns non-zero status, but creates kafka-connection anyway.
Importing existing connections is tricky, because needed manually finding _connection id_ and tweak `cloud.py` wrapper.

With this PR terraform could import existing connection rather then create new one if connection with that name already exists.

If this behavioud not preferred, I can change `import_existing_connection = False`
Then importing existing connections would be possible by change the variable in local script in `.terragrunt-cache` dir.